### PR TITLE
Rotate Django secret key and ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,8 +127,10 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
+# Local environment variables
 .env
+*.env
+# Virtual environments
 .venv
 env/
 venv/

--- a/opensec_project/settings.py
+++ b/opensec_project/settings.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+import os
+from django.core.management.utils import get_random_secret_key
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = 'change-me'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', get_random_secret_key())
 DEBUG = True
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
## Summary
- rotate the Django `SECRET_KEY`
- read `SECRET_KEY` from `DJANGO_SECRET_KEY` environment variable with a fallback random value
- ignore local `.env` files and add a glob for `*.env` in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ec4b95dc832ba613c5ccdae0f2ec