### PR TITLE
Add default categories migration

### DIFF
--- a/resources/migrations/0002_default_categories.py
+++ b/resources/migrations/0002_default_categories.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def add_default_categories(apps, schema_editor):
+    Category = apps.get_model('resources', 'Category')
+    categories = [
+        'Web',
+        'Networking',
+        'Linux',
+        'Operating Systems',
+        'Security',
+        'Tools',
+        'Programming',
+    ]
+    for name in categories:
+        Category.objects.get_or_create(name=name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_default_categories, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- populate a list of default categories

## Testing
- `python -m py_compile resources/migrations/0002_default_categories.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6856711d0978832b8fdb13fa84bdc060