### PR TITLE
Limit upvotes per session

### DIFF
--- a/resources/tests.py
+++ b/resources/tests.py
@@ -4,7 +4,7 @@ from .models import Category, Resource
 
 class ResourceOrderingTest(TestCase):
     def test_order_by_upvotes(self):
-        cat = Category.objects.create(name='Tools')
+        cat = Category.objects.create(name='TestCat')
         r1 = Resource.objects.create(url='http://a.com', description='A', category=cat, upvotes=1)
         r2 = Resource.objects.create(url='http://b.com', description='B', category=cat, upvotes=5)
         r3 = Resource.objects.create(url='http://c.com', description='C', category=cat, upvotes=3)
@@ -12,3 +12,17 @@ class ResourceOrderingTest(TestCase):
         self.assertEqual(resources[0], r2)
         self.assertEqual(resources[1], r3)
         self.assertEqual(resources[2], r1)
+
+
+class UpvoteLimitTest(TestCase):
+    def test_single_upvote_per_session(self):
+        cat = Category.objects.create(name='TestCat2')
+        res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
+
+        response = self.client.get(f'/upvote/{res.pk}/')
+        res.refresh_from_db()
+        self.assertEqual(res.upvotes, 1)
+
+        response = self.client.get(f'/upvote/{res.pk}/')
+        res.refresh_from_db()
+        self.assertEqual(res.upvotes, 1)

--- a/resources/views.py
+++ b/resources/views.py
@@ -26,6 +26,10 @@ class CategoryCreateView(CreateView):
 
 def upvote(request, pk):
     resource = get_object_or_404(Resource, pk=pk)
-    resource.upvotes += 1
-    resource.save()
+    upvoted = request.session.get('upvoted_resources', [])
+    if pk not in upvoted:
+        resource.upvotes += 1
+        resource.save()
+        upvoted.append(pk)
+        request.session['upvoted_resources'] = upvoted
     return redirect('resource_list')

--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -35,7 +35,11 @@
         {% for resource in resources %}
         <li>
             <a href="{{ resource.url }}">{{ resource.description }}</a> - {{ resource.category.name }} - Upvotes: {{ resource.upvotes }}
-            <a href="{% url 'resource_upvote' resource.pk %}" class="button">Upvote</a>
+            {% if request.session.upvoted_resources and resource.pk in request.session.upvoted_resources %}
+                <span>Upvoted</span>
+            {% else %}
+                <a href="{% url 'resource_upvote' resource.pk %}" class="button">Upvote</a>
+            {% endif %}
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- prevent multiple upvotes in a single session
- show `Upvoted` label in list page if user already upvoted
- test upvote limit logic

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6856743d5174832bb4c403e4bbe0e419