### PR TITLE
Add website thumbnails for listed resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project provides a simple Django application for collecting and ranking cybersecurity resources by upvotes.
 
+Each resource on the list page now displays a small thumbnail preview fetched from [thum.io](https://thum.io/), making it easier to identify links at a glance.
+
 ## Setup
 
 1. Ensure Django is installed (`pip install django`).

--- a/resources/models.py
+++ b/resources/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from urllib.parse import quote
 
 
 class Category(models.Model):
@@ -20,3 +21,8 @@ class Resource(models.Model):
 
     def __str__(self):
         return self.url
+
+    @property
+    def thumbnail_url(self):
+        encoded_url = quote(self.url, safe='')
+        return f"https://image.thum.io/get/{encoded_url}"

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -26,3 +26,14 @@ class UpvoteLimitTest(TestCase):
         response = self.client.get(f'/upvote/{res.pk}/')
         res.refresh_from_db()
         self.assertEqual(res.upvotes, 1)
+
+
+class ThumbnailURLTest(TestCase):
+    def test_thumbnail_url_format(self):
+        cat = Category.objects.create(name='ThumbCat')
+        res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
+        self.assertEqual(
+            res.thumbnail_url,
+            'https://image.thum.io/get/http%3A%2F%2Fexample.com'
+        )
+

--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -24,6 +24,15 @@
             margin: 8px 0;
             padding: 10px;
             border-radius: 4px;
+            display: flex;
+            align-items: center;
+        }
+        img.thumbnail {
+            width: 120px;
+            height: 90px;
+            margin-right: 10px;
+            object-fit: cover;
+            border-radius: 4px;
         }
     </style>
 </head>
@@ -34,6 +43,7 @@
     <ul>
         {% for resource in resources %}
         <li>
+            <img class="thumbnail" src="{{ resource.thumbnail_url }}" alt="{{ resource.description }} thumbnail">
             <a href="{{ resource.url }}">{{ resource.description }}</a> - {{ resource.category.name }} - Upvotes: {{ resource.upvotes }}
             {% if request.session.upvoted_resources and resource.pk in request.session.upvoted_resources %}
                 <span>Upvoted</span>


### PR DESCRIPTION
## Summary
- fetch screenshot thumbnails with `thum.io`
- show thumbnails in resource list
- expose a `thumbnail_url` property on `Resource`
- document thumbnail feature in README
- test thumbnail URL formatting

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685675a287f8832b8c7fd8ed74b077b3