### PR TITLE
Fix thumbnail URL quoting

### DIFF
--- a/resources/models.py
+++ b/resources/models.py
@@ -24,5 +24,6 @@ class Resource(models.Model):
 
     @property
     def thumbnail_url(self):
-        encoded_url = quote(self.url, safe='')
+        """Return the screenshot URL for the resource."""
+        encoded_url = quote(self.url, safe=':/')
         return f"https://image.thum.io/get/{encoded_url}"

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -34,6 +34,6 @@ class ThumbnailURLTest(TestCase):
         res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
         self.assertEqual(
             res.thumbnail_url,
-            'https://image.thum.io/get/http%3A%2F%2Fexample.com'
+            'https://image.thum.io/get/http://example.com'
         )
 


### PR DESCRIPTION
## Summary
- ensure the URL passed to thum.io keeps the scheme
- update tests for new thumbnail path

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685677483b3c832b9aa110eac69aea55