### PR TITLE
Change screenshot service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides a simple Django application for collecting and ranking cybersecurity resources by upvotes.
 
 Each resource on the list page now displays a small thumbnail preview fetched from
-[thum.io](https://thum.io/). The screenshots are requested with dark mode enabled
+[microlink.io](https://microlink.io/). The screenshots are requested with a `colorScheme=dark`
 so thumbnails match the rest of the interface.
 
 ## Setup

--- a/resources/models.py
+++ b/resources/models.py
@@ -26,6 +26,6 @@ class Resource(models.Model):
     def thumbnail_url(self):
         """Return the screenshot URL for the resource."""
         encoded_url = quote(self.url, safe=':/')
-        # Request the screenshot with dark mode enabled so thumbnails
-        # reflect how the site appears when a browser prefers a dark theme.
-        return f"https://image.thum.io/get/dark/{encoded_url}"
+        # Use microlink.io to request a screenshot. The colorScheme parameter
+        # forces a dark theme so thumbnails match the rest of the interface.
+        return f"https://image.microlink.io/{encoded_url}?colorScheme=dark"

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -34,6 +34,6 @@ class ThumbnailURLTest(TestCase):
         res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
         self.assertEqual(
             res.thumbnail_url,
-            'https://image.thum.io/get/dark/http://example.com'
+            'https://image.microlink.io/http://example.com?colorScheme=dark'
         )
 


### PR DESCRIPTION
## Summary
- switch thumbnail provider to microlink with dark mode
- update tests for new URL
- update README accordingly

## Testing
- `pytest -q` *(fails: no tests detected)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68567ad73f4c832ba69e4b823948296b