### PR TITLE
Fix microlink thumbnail URL format

### DIFF
--- a/resources/models.py
+++ b/resources/models.py
@@ -26,6 +26,8 @@ class Resource(models.Model):
     def thumbnail_url(self):
         """Return the screenshot URL for the resource."""
         encoded_url = quote(self.url, safe=':/')
-        # Use microlink.io to request a screenshot. The colorScheme parameter
-        # forces a dark theme so thumbnails match the rest of the interface.
-        return f"https://image.microlink.io/{encoded_url}?colorScheme=dark"
+        # Use microlink.io to request a screenshot with dark theme enabled.
+        # The service expects the target URL as a query parameter.
+        return (
+            f"https://image.microlink.io/?url={encoded_url}&colorScheme=dark"
+        )

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -34,6 +34,6 @@ class ThumbnailURLTest(TestCase):
         res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
         self.assertEqual(
             res.thumbnail_url,
-            'https://image.microlink.io/http://example.com?colorScheme=dark'
+            'https://image.microlink.io/?url=http://example.com&colorScheme=dark'
         )
 


### PR DESCRIPTION
## Summary
- update thumbnail URL generation to use `?url=` query param
- update tests for new thumbnail URL format

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q` *(no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_68567bf481c8832b87dde65d347e66df