### PR TITLE
Use thum.io thumbnails with server-side inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This project provides a simple Django application for collecting and ranking cybersecurity resources by upvotes.
 
-Each resource on the list page now displays a small thumbnail preview fetched from
-[microlink.io](https://microlink.io/). The screenshots are requested with a `colorScheme=dark`
-so thumbnails match the rest of the interface.
+Each resource on the list page displays a small thumbnail preview generated
+server side. Thumbnails are fetched from [thum.io](https://www.thum.io/). The
+image is then inverted using Pillow so the preview fits the application's dark
+theme.
 
 ## Setup
 

--- a/resources/models.py
+++ b/resources/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from urllib.parse import quote
+from django.urls import reverse
 
 
 class Category(models.Model):
@@ -24,10 +24,5 @@ class Resource(models.Model):
 
     @property
     def thumbnail_url(self):
-        """Return the screenshot URL for the resource."""
-        encoded_url = quote(self.url, safe=':/')
-        # Use microlink.io to request a screenshot with dark theme enabled.
-        # The service expects the target URL as a query parameter.
-        return (
-            f"https://image.microlink.io/?url={encoded_url}&colorScheme=dark"
-        )
+        """Return the URL of the generated thumbnail."""
+        return reverse("resource_thumbnail", args=[self.pk])

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -32,8 +32,6 @@ class ThumbnailURLTest(TestCase):
     def test_thumbnail_url_format(self):
         cat = Category.objects.create(name='ThumbCat')
         res = Resource.objects.create(url='http://example.com', description='Ex', category=cat)
-        self.assertEqual(
-            res.thumbnail_url,
-            'https://image.microlink.io/?url=http://example.com&colorScheme=dark'
-        )
+        expected = f'/thumbnail/{res.pk}/'
+        self.assertEqual(res.thumbnail_url, expected)
 

--- a/resources/urls.py
+++ b/resources/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('add/', views.ResourceCreateView.as_view(), name='resource_add'),
     path('category/add/', views.CategoryCreateView.as_view(), name='category_add'),
     path('upvote/<int:pk>/', views.upvote, name='resource_upvote'),
+    path('thumbnail/<int:pk>/', views.thumbnail, name='resource_thumbnail'),
 ]


### PR DESCRIPTION
## Summary
- add README notes on using thum.io thumbnails
- replace thumbnail_url with route to new thumbnail view
- implement thumbnail view that fetches from thum.io and inverts colors
- expose the new thumbnail route
- adjust unit test to expect new thumbnail URL format

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68567f16b420832bb0398b4447f913f6