### PR TITLE
Add CSS inversion for thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides a simple Django application for collecting and ranking cyb
 
 Each resource on the list page displays a small thumbnail preview generated
 server side. Thumbnails are fetched from [thum.io](https://www.thum.io/). The
-image is then inverted using Pillow so the preview fits the application's dark
+image is inverted in CSS so the preview fits the application's dark
 theme.
 
 ## Setup

--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -33,7 +33,7 @@
             margin-right: 10px;
             object-fit: cover;
             border-radius: 4px;
-            filter: brightness(0.6);
+            filter: invert(1) brightness(0.6);
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak dark theme docs
- invert thumbnails with CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685682499508832b8cb6ffaa3c81394b