### PR TITLE
Add resource sorting and filtering

### DIFF
--- a/resources/tests.py
+++ b/resources/tests.py
@@ -35,3 +35,23 @@ class ThumbnailURLTest(TestCase):
         expected = f'/thumbnail/{res.pk}/'
         self.assertEqual(res.thumbnail_url, expected)
 
+
+class ListViewFilterSortTest(TestCase):
+    def setUp(self):
+        self.cat1 = Category.objects.create(name='Cat1')
+        self.cat2 = Category.objects.create(name='Cat2')
+        self.r1 = Resource.objects.create(url='http://1.com', description='R1', category=self.cat1, upvotes=1)
+        self.r2 = Resource.objects.create(url='http://2.com', description='R2', category=self.cat2, upvotes=5)
+        self.r3 = Resource.objects.create(url='http://3.com', description='R3', category=self.cat1, upvotes=2)
+
+    def test_filter_by_category(self):
+        response = self.client.get('/', {'category': self.cat1.id})
+        resources = list(response.context['resources'])
+        self.assertEqual(resources, [self.r3, self.r1])
+
+    def test_sort_by_created(self):
+        response = self.client.get('/', {'sort': 'created'})
+        resources = list(response.context['resources'])
+        self.assertEqual(resources[0], self.r3)
+        self.assertEqual(resources[-1], self.r1)
+

--- a/resources/views.py
+++ b/resources/views.py
@@ -12,6 +12,26 @@ class ResourceListView(ListView):
     template_name = 'resources/list.html'
     context_object_name = 'resources'
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        category_id = self.request.GET.get("category")
+        if category_id:
+            queryset = queryset.filter(category_id=category_id)
+
+        sort = self.request.GET.get("sort")
+        if sort == "created":
+            queryset = queryset.order_by("-created")
+        elif sort == "upvotes":
+            queryset = queryset.order_by("-upvotes")
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["categories"] = Category.objects.all()
+        context["selected_category"] = self.request.GET.get("category", "")
+        context["selected_sort"] = self.request.GET.get("sort", "")
+        return context
+
 
 class ResourceCreateView(CreateView):
     model = Resource

--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -11,6 +11,7 @@
             padding: 20px;
         }
         a { color: #90caf9; }
+        .button,
         a.button {
             background: #1e88e5;
             color: #fff;
@@ -28,6 +29,14 @@
         /* Match spacing for the "Upvoted" text shown after voting */
         span.upvoted-text {
             margin-left: 12px;
+        }
+        select {
+            background: #1e1e1e;
+            color: #f0f0f0;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 4px 8px;
+            margin-right: 8px;
         }
         h1 {
             margin-top: 0;
@@ -60,6 +69,21 @@
     <h1>Resources</h1>
     <a href="{% url 'resource_add' %}" class="button">Add Resource</a>
     <a href="{% url 'category_add' %}" class="button">Add Category</a>
+    <form method="get" style="margin-top:20px;">
+        <label for="category">Category:</label>
+        <select name="category" id="category">
+            <option value="">All</option>
+            {% for cat in categories %}
+                <option value="{{ cat.id }}" {% if cat.id|stringformat:'s' == selected_category %}selected{% endif %}>{{ cat.name }}</option>
+            {% endfor %}
+        </select>
+        <label for="sort">Sort by:</label>
+        <select name="sort" id="sort">
+            <option value="upvotes" {% if selected_sort == 'upvotes' %}selected{% endif %}>Upvotes</option>
+            <option value="created" {% if selected_sort == 'created' %}selected{% endif %}>Newest</option>
+        </select>
+        <button type="submit" class="button filter-button">Apply</button>
+    </form>
     <ul>
         {% for resource in resources %}
         <li>


### PR DESCRIPTION
## Summary
- filter and sort resources in list view
- expose sorting/filtering controls in template
- test category filtering and created-date sort

## Testing
- `venv/bin/python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6856891a7dd4832bbda731c7c8b0e4bb