### PR TITLE
Auto-apply filters on change

### DIFF
--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -82,8 +82,16 @@
             <option value="upvotes" {% if selected_sort == 'upvotes' %}selected{% endif %}>Upvotes</option>
             <option value="created" {% if selected_sort == 'created' %}selected{% endif %}>Newest</option>
         </select>
-        <button type="submit" class="button filter-button">Apply</button>
+        <button type="submit" class="button filter-button" style="display:none;">Apply</button>
     </form>
+    <script>
+        document.getElementById('category').addEventListener('change', function () {
+            this.form.submit();
+        });
+        document.getElementById('sort').addEventListener('change', function () {
+            this.form.submit();
+        });
+    </script>
     <ul>
         {% for resource in resources %}
         <li>


### PR DESCRIPTION
## Summary
- make category/sort dropdowns submit automatically

## Testing
- `pytest -q`
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_68568a1a0804832bb664689023c1cda6