### PR TITLE
Link thumbnails to resources

### DIFF
--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -95,7 +95,9 @@
     <ul>
         {% for resource in resources %}
         <li>
-            <img class="thumbnail" src="{{ resource.thumbnail_url }}" alt="{{ resource.description }} thumbnail">
+            <a href="{{ resource.url }}">
+                <img class="thumbnail" src="{{ resource.thumbnail_url }}" alt="{{ resource.description }} thumbnail">
+            </a>
             <a href="{{ resource.url }}">{{ resource.description }}</a> - {{ resource.category.name }} - Upvotes: {{ resource.upvotes }}
             {% if request.session.upvoted_resources and resource.pk in request.session.upvoted_resources %}
                 <span class="upvoted-text">Upvoted</span>


### PR DESCRIPTION
## Summary
- make screenshot thumbnails clickable by wrapping them in an anchor tag

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68568b753998832baaa0963ad3e239cd