### PR TITLE
Add security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ server side. Thumbnails are fetched from [thum.io](https://www.thum.io/). The
 image is inverted in CSS so the preview fits the application's dark
 theme.
 
+## Security
+
+The application enables several security-related HTTP headers via
+Django's `SecurityMiddleware`. These include a referrer policy of
+`same-origin` and the `X-Content-Type-Options` header to prevent MIME
+type sniffing. Session and CSRF cookies are also marked as secure when
+the environment provides HTTPS.
+
 ## Setup
 
 1. Ensure Django is installed (`pip install django`).

--- a/opensec_project/settings.py
+++ b/opensec_project/settings.py
@@ -69,3 +69,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Simple rate limiting settings
 RATE_LIMIT_REQUESTS = int(os.environ.get('RATE_LIMIT_REQUESTS', '60'))
 RATE_LIMIT_WINDOW = int(os.environ.get('RATE_LIMIT_WINDOW', '60'))
+
+# Security-related settings
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = 'same-origin'
+SECURE_HSTS_SECONDS = int(os.environ.get('SECURE_HSTS_SECONDS', '0'))
+SECURE_SSL_REDIRECT = os.environ.get('SECURE_SSL_REDIRECT', 'False') == 'True'
+SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True') == 'True'
+CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'True') == 'True'

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -71,3 +71,14 @@ class RateLimitMiddlewareTest(TestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 429)
 
+
+class SecurityHeadersTest(TestCase):
+    @override_settings(
+        SECURE_CONTENT_TYPE_NOSNIFF=True,
+        SECURE_REFERRER_POLICY='same-origin',
+    )
+    def test_security_headers_present(self):
+        response = self.client.get('/')
+        self.assertEqual(response['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(response['Referrer-Policy'], 'same-origin')
+


### PR DESCRIPTION
## Summary
- configure Django security headers via SecurityMiddleware
- test that security headers are present
- document security features in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68568f3c3764832b84d052877073c419