### PR TITLE
Extend search to include URLs

### DIFF
--- a/templates/resources/list.html
+++ b/templates/resources/list.html
@@ -96,7 +96,9 @@
             const filter = this.value.toLowerCase();
             document.querySelectorAll('ul li').forEach(function(li) {
                 const text = li.textContent.toLowerCase();
-                li.style.display = text.includes(filter) ? '' : 'none';
+                var link = li.querySelector('a[href^="http"]');
+                var url = link ? link.getAttribute('href').toLowerCase() : '';
+                li.style.display = (text.includes(filter) || url.includes(filter)) ? '' : 'none';
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- filter JS now matches URL too in real-time search

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685692c7a228832b9c6c5ae6c58f0bfb