### PR TITLE
Add login-protected admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ the environment provides HTTPS.
 
 ## Setup
 
+
 1. Ensure Django is installed (`pip install django`).
 2. Run migrations:
 
@@ -24,10 +25,16 @@ the environment provides HTTPS.
 python manage.py migrate
 ```
 
-3. Start the server:
+3. Create a superuser:
+
+```bash
+python manage.py createsuperuser
+```
+
+4. Start the server:
 
 ```bash
 python manage.py runserver
 ```
 
-Visit `http://localhost:8000/` to see the resources list.
+Visit `http://localhost:8000/` to see the resources list and `http://localhost:8000/manage/` for the admin panel.

--- a/opensec_project/urls.py
+++ b/opensec_project/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("accounts/login/", auth_views.LoginView.as_view(), name="login"),
+    path("accounts/logout/", auth_views.LogoutView.as_view(next_page="/"), name="logout"),
     path('', include('resources.urls')),
 ]

--- a/resources/urls.py
+++ b/resources/urls.py
@@ -4,6 +4,10 @@ from . import views
 urlpatterns = [
     path('', views.ResourceListView.as_view(), name='resource_list'),
     path('add/', views.ResourceCreateView.as_view(), name='resource_add'),
+    path("manage/", views.ResourceAdminListView.as_view(), name="admin_resource_list"),
+    path("manage/add/", views.ResourceAdminCreateView.as_view(), name="admin_resource_add"),
+    path("manage/<int:pk>/edit/", views.ResourceAdminUpdateView.as_view(), name="admin_resource_edit"),
+    path("manage/<int:pk>/delete/", views.ResourceAdminDeleteView.as_view(), name="admin_resource_delete"),
     path('category/add/', views.CategoryCreateView.as_view(), name='category_add'),
     path('upvote/<int:pk>/', views.upvote, name='resource_upvote'),
     path('thumbnail/<int:pk>/', views.thumbnail, name='resource_thumbnail'),

--- a/resources/views.py
+++ b/resources/views.py
@@ -6,6 +6,10 @@ from .models import Resource, Category
 import io
 from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import user_passes_test
+from django.views.generic import UpdateView, DeleteView
+staff_member_required = user_passes_test(lambda u: u.is_staff)
 
 
 class ResourceListView(ListView):
@@ -86,3 +90,31 @@ def thumbnail(request, pk):
         return HttpResponse(buffer.getvalue(), content_type="image/png")
     except Exception as exc:
         raise Http404 from exc
+@method_decorator(staff_member_required, name='dispatch')
+class ResourceAdminListView(ListView):
+    model = Resource
+    template_name = 'resources/admin_list.html'
+    context_object_name = 'resources'
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class ResourceAdminCreateView(CreateView):
+    model = Resource
+    fields = ['url', 'description', 'category']
+    template_name = 'resources/admin_form.html'
+    success_url = reverse_lazy('admin_resource_list')
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class ResourceAdminUpdateView(UpdateView):
+    model = Resource
+    fields = ['url', 'description', 'category', 'upvotes']
+    template_name = 'resources/admin_form.html'
+    success_url = reverse_lazy('admin_resource_list')
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class ResourceAdminDeleteView(DeleteView):
+    model = Resource
+    template_name = 'resources/admin_confirm_delete.html'
+    success_url = reverse_lazy('admin_resource_list')

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <style>
+        body {
+            background-color: #121212;
+            color: #f0f0f0;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        button {
+            background: #1e88e5;
+            color: #fff;
+            padding: 8px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 12px;
+        }
+        input {
+            background: #1e1e1e;
+            color: #f0f0f0;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 6px 10px;
+        }
+        form p { margin: 12px 0; }
+    </style>
+</head>
+<body>
+    <h1>Login</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/templates/resources/admin_confirm_delete.html
+++ b/templates/resources/admin_confirm_delete.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Confirm Delete</title>
+    <style>
+        body {
+            background-color: #121212;
+            color: #f0f0f0;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        button {
+            background: #1e88e5;
+            color: #fff;
+            padding: 8px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 12px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Delete Resource</h1>
+    <p>Are you sure you want to delete "{{ object }}"?</p>
+    <form method="post">
+        {% csrf_token %}
+        <button type="submit">Confirm</button>
+    </form>
+</body>
+</html>

--- a/templates/resources/admin_form.html
+++ b/templates/resources/admin_form.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Resource Form</title>
+    <style>
+        body {
+            background-color: #121212;
+            color: #f0f0f0;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        a { color: #90caf9; }
+        button {
+            background: #1e88e5;
+            color: #fff;
+            padding: 8px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 12px;
+        }
+        input, select, textarea {
+            background: #1e1e1e;
+            color: #f0f0f0;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 6px 10px;
+        }
+        form p {
+            margin: 12px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>{% if object %}Edit{% else %}Add{% endif %} Resource</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/templates/resources/admin_list.html
+++ b/templates/resources/admin_list.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Manage Resources</title>
+    <style>
+        body {
+            background-color: #121212;
+            color: #f0f0f0;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        a { color: #90caf9; }
+        .button {
+            background: #1e88e5;
+            color: #fff;
+            padding: 8px 12px;
+            text-decoration: none;
+            border-radius: 4px;
+            margin-right: 8px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            padding: 8px;
+            border: 1px solid #444;
+        }
+    </style>
+</head>
+<body>
+    <h1>Manage Resources</h1>
+    <a href="{% url 'admin_resource_add' %}" class="button">Add Resource</a>
+    <table>
+        <tr>
+            <th>ID</th>
+            <th>URL</th>
+            <th>Description</th>
+            <th>Category</th>
+            <th>Upvotes</th>
+            <th>Actions</th>
+        </tr>
+        {% for res in resources %}
+        <tr>
+            <td>{{ res.id }}</td>
+            <td><a href="{{ res.url }}">{{ res.url }}</a></td>
+            <td>{{ res.description }}</td>
+            <td>{{ res.category.name }}</td>
+            <td>{{ res.upvotes }}</td>
+            <td>
+                <a href="{% url 'admin_resource_edit' res.pk %}">Edit</a>
+                |
+                <a href="{% url 'admin_resource_delete' res.pk %}">Delete</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create admin views for managing `Resource`
- protect the new admin views with a staff-only login
- expose login/logout URLs
- add simple admin templates and login template
- document how to create a superuser and access the admin panel

## Testing
- `venv/bin/python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685a0f92aa80832ba2bb30a7eb3c66fc